### PR TITLE
Fix dataset field validation

### DIFF
--- a/dataset_loading_fix.py
+++ b/dataset_loading_fix.py
@@ -39,9 +39,12 @@ def load_training_data(file_path="processed_data.json", field='data'):
         dataset = load_dataset_safely(file_path, field)
 
         # Validate required fields
-        required_fields = ['query_vi', 'response_vi']
+        required_fields = ["query_vi", "response_vi"]
+        # `Dataset.features` is not always iterable in membership checks.
+        # Using `column_names` ensures we are checking against the actual
+        # column names present in the dataset to avoid false negatives.
         missing_fields = [field for field in required_fields
-                         if field not in dataset.features]
+                          if field not in dataset.column_names]
 
         if missing_fields:
             raise ValueError(f"Dataset is missing required fields: {missing_fields}")


### PR DESCRIPTION
## Summary
- ensure dataset field checks use column names instead of `dataset.features` to avoid membership errors

## Testing
- `python -m py_compile dataset_loading_fix.py`
- `python - <<'PY'
from dataset_loading_fix import load_training_data
import json
sample={'data':[{'query_vi':'1+1?','response_vi':'2'}]}
with open('sample.json','w',encoding='utf-8') as f:
    json.dump(sample,f)
print(load_training_data('sample.json'))
sample={'data':[{'query_vi':'1+1?'}]}
with open('sample_missing.json','w',encoding='utf-8') as f:
    json.dump(sample,f)
try:
    load_training_data('sample_missing.json')
except Exception as e:
    print('error', e)
PY`


------
https://chatgpt.com/codex/tasks/task_b_68a023f213d8832e9de3cfac402deb7f